### PR TITLE
More clarity, less verbosity

### DIFF
--- a/src/main/resources/assets/controlify/lang/en_us.json
+++ b/src/main/resources/assets/controlify/lang/en_us.json
@@ -220,7 +220,7 @@
   "controlify.beta.button": "Open Issue Tracker...",
 
   "controlify.error.hid": "Controller Detection Disabled",
-  "controlify.error.hid.desc": "Controlify could not start the controller detection system used to identify and distinguish between multiple controllers. This means controller config will not be able to be saved between play sessions. This is likely due to a system fault and you should check logs for further information.",
+  "controlify.error.hid.desc": "Controllify's controller identification failed and controller config changes will not persist. Check logs for more info.",
 
   "controlify.hat_state.up": "Up",
   "controlify.hat_state.down": "Down",

--- a/src/main/resources/assets/controlify/lang/en_us.json
+++ b/src/main/resources/assets/controlify/lang/en_us.json
@@ -118,7 +118,7 @@
   "controlify.toast.controller_disconnected.title": "Controller Disconnected",
   "controlify.toast.controller_disconnected.description": "'%s' was disconnected.",
   "controlify.toast.faulty_input.title": "Controller disabled",
-  "controlify.toast.faulty_input.description": "The controller was found conflicting with keyboard and mouse and therefore is now disabled. Increase deadzone values or check joystick mapping to fix.",
+  "controlify.toast.faulty_input.description": "The controller was found to conflict with the keyboard and mouse and is now disabled. Increase deadzone values or check joystick mapping to fix.",
 
   "controlify.vibration_onboarding.title": "Controlify Vibration Support",
   "controlify.vibration_onboarding.message": "To enable vibration support, a native library must be downloaded that Controlify loads automatically. This is a seamless process and will only take a few seconds. If you choose no, you may change your mind later in Controlify settings.\n\nWould you like to download them?",

--- a/src/main/resources/assets/controlify/lang/en_us.json
+++ b/src/main/resources/assets/controlify/lang/en_us.json
@@ -118,7 +118,7 @@
   "controlify.toast.controller_disconnected.title": "Controller Disconnected",
   "controlify.toast.controller_disconnected.description": "'%s' was disconnected.",
   "controlify.toast.faulty_input.title": "Controller disabled",
-  "controlify.toast.faulty_input.description": "Your controller has been disabled because Controlify detected it was causing you problems using keyboard and mouse input. This is likely due to setting your deadzone values too low or your joystick is not mapped properly, making the controller think it is always giving input.",
+  "controlify.toast.faulty_input.description": "The controller was found conflicting with keyboard and mouse and therefore is now disabled. Increase deadzone values or check joystick mapping to fix.",
 
   "controlify.vibration_onboarding.title": "Controlify Vibration Support",
   "controlify.vibration_onboarding.message": "To enable vibration support, a native library must be downloaded that Controlify loads automatically. This is a seamless process and will only take a few seconds. If you choose no, you may change your mind later in Controlify settings.\n\nWould you like to download them?",

--- a/src/main/resources/assets/controlify/lang/en_us.json
+++ b/src/main/resources/assets/controlify/lang/en_us.json
@@ -220,7 +220,7 @@
   "controlify.beta.button": "Open Issue Tracker...",
 
   "controlify.error.hid": "Controller Detection Disabled",
-  "controlify.error.hid.desc": "Controllify's controller identification failed and controller config changes will not persist. Check logs for more info.",
+  "controlify.error.hid.desc": "Controller identification failed, so any controller config changes will not persist. Check logs for more info.",
 
   "controlify.hat_state.up": "Up",
   "controlify.hat_state.down": "Down",


### PR DESCRIPTION
Being too verbose in toasts is
* harder for non-native speakers
* too much to read for everyone
* unclear overall

As such, I replaced the sentences with shorter ones that have the same details. You can still explain the issues in longer form in a wiki or such.