### PR TITLE
More recipe book SnapPoints

### DIFF
--- a/src/main/java/dev/isxander/controlify/mixins/feature/virtualmouse/snapping/RecipeBookComponentAccessor.java
+++ b/src/main/java/dev/isxander/controlify/mixins/feature/virtualmouse/snapping/RecipeBookComponentAccessor.java
@@ -1,5 +1,6 @@
 package dev.isxander.controlify.mixins.feature.virtualmouse.snapping;
 
+import net.minecraft.client.gui.components.StateSwitchingButton;
 import net.minecraft.client.gui.screens.recipebook.RecipeBookComponent;
 import net.minecraft.client.gui.screens.recipebook.RecipeBookPage;
 import net.minecraft.client.gui.screens.recipebook.RecipeBookTabButton;
@@ -15,4 +16,7 @@ public interface RecipeBookComponentAccessor {
 
     @Accessor
     List<RecipeBookTabButton> getTabButtons();
+
+    @Accessor
+    StateSwitchingButton getFilterButton();
 }

--- a/src/main/java/dev/isxander/controlify/mixins/feature/virtualmouse/snapping/RecipeBookPageAccessor.java
+++ b/src/main/java/dev/isxander/controlify/mixins/feature/virtualmouse/snapping/RecipeBookPageAccessor.java
@@ -1,5 +1,6 @@
 package dev.isxander.controlify.mixins.feature.virtualmouse.snapping;
 
+import net.minecraft.client.gui.components.StateSwitchingButton;
 import net.minecraft.client.gui.screens.recipebook.RecipeBookPage;
 import net.minecraft.client.gui.screens.recipebook.RecipeButton;
 import org.spongepowered.asm.mixin.Mixin;
@@ -11,4 +12,10 @@ import java.util.List;
 public interface RecipeBookPageAccessor {
     @Accessor
     List<RecipeButton> getButtons();
+
+    @Accessor
+    StateSwitchingButton getForwardButton();
+
+    @Accessor
+    StateSwitchingButton getBackButton();
 }

--- a/src/main/java/dev/isxander/controlify/virtualmouse/SnapUtils.java
+++ b/src/main/java/dev/isxander/controlify/virtualmouse/SnapUtils.java
@@ -3,6 +3,7 @@ package dev.isxander.controlify.virtualmouse;
 import dev.isxander.controlify.api.vmousesnapping.SnapPoint;
 import dev.isxander.controlify.mixins.feature.virtualmouse.snapping.RecipeBookComponentAccessor;
 import dev.isxander.controlify.mixins.feature.virtualmouse.snapping.RecipeBookPageAccessor;
+import net.minecraft.client.gui.components.StateSwitchingButton;
 import net.minecraft.client.gui.screens.recipebook.RecipeBookComponent;
 import org.joml.Vector2i;
 
@@ -21,12 +22,33 @@ public final class SnapUtils {
                 points.add(new SnapPoint(new Vector2i(x, y), 20));
             });
 
+            StateSwitchingButton filterButton = componentAccessor.getFilterButton();
+            if (filterButton.visible) {
+                int x = filterButton.getX() + filterButton.getWidth() / 2;
+                int y = filterButton.getY() + filterButton.getHeight() / 2;
+                points.add(new SnapPoint(new Vector2i(x, y), 14));
+            }
+
             RecipeBookPageAccessor pageAccessor = (RecipeBookPageAccessor) componentAccessor.getRecipeBookPage();
             pageAccessor.getButtons().forEach(button -> {
                 int x = button.getX() + button.getWidth() / 2;
                 int y = button.getY() + button.getHeight() / 2;
                 points.add(new SnapPoint(new Vector2i(x, y), 21));
             });
+
+            StateSwitchingButton forwardButton = pageAccessor.getForwardButton();
+            if (forwardButton.visible) {
+                int x = forwardButton.getX() + forwardButton.getWidth() / 2 - 2;
+                int y = forwardButton.getY() + forwardButton.getHeight() / 2;
+                points.add(new SnapPoint(new Vector2i(x, y), 10));
+            }
+
+            StateSwitchingButton backButton = pageAccessor.getBackButton();
+            if (backButton.visible) {
+                int x = backButton.getX() + backButton.getWidth() / 2 + 2;
+                int y = backButton.getY() + backButton.getHeight() / 2;
+                points.add(new SnapPoint(new Vector2i(x, y), 10));
+            }
         }
     }
 }


### PR DESCRIPTION
while testing D-pad navigation I noticed some missing SnapPoints

affected buttons:
- page-forward
- page-back
- filter-toggle

notes:
- looked at the recipe-book button itself as well, it doesn't have variables outside its textures, then it's just hardcoded into place