### PR TITLE
improve snapInDirection logic

### DIFF
--- a/src/main/java/dev/isxander/controlify/virtualmouse/VirtualMouseHandler.java
+++ b/src/main/java/dev/isxander/controlify/virtualmouse/VirtualMouseHandler.java
@@ -214,16 +214,21 @@ public class VirtualMouseHandler {
                     SnapPoint snapPoint = pair.getFirst();
                     Vector2d dist = pair.getSecond();
 
+                    // distance in the correct orthogonal direction
                     double distance = Math.abs(direction.getAxis() == ScreenAxis.HORIZONTAL ? dist.x : dist.y);
+                    // distance in the incorrect orthogonal direction
                     double deviation = Math.abs(direction.getAxis() == ScreenAxis.HORIZONTAL ? dist.y : dist.x);
 
+                    // punish deviation significantly
                     pair.getSecond().set(distance, deviation * 4);
 
+                    // reject if the deviation is double the correct direction away
                     return distance >= snapPoint.range() && (deviation < distance * 2);
                 })
                 // pick the closest point
                 .min(Comparator.comparingDouble(pair -> {
                     Vector2d distDev = pair.getSecond();
+                    // x = dist, y = deviation
                     return distDev.x + distDev.y;
                 }))
                 .map(Pair::getFirst);

--- a/src/main/java/dev/isxander/controlify/virtualmouse/VirtualMouseHandler.java
+++ b/src/main/java/dev/isxander/controlify/virtualmouse/VirtualMouseHandler.java
@@ -217,9 +217,9 @@ public class VirtualMouseHandler {
                     double distance = Math.abs(direction.getAxis() == ScreenAxis.HORIZONTAL ? dist.x : dist.y);
                     double deviation = Math.abs(direction.getAxis() == ScreenAxis.HORIZONTAL ? dist.y : dist.x);
 
-                    pair.getSecond().set(distance, deviation);
+                    pair.getSecond().set(distance, deviation * 4);
 
-                    return distance >= snapPoint.range();
+                    return distance >= snapPoint.range() && (deviation < distance * 2);
                 })
                 // pick the closest point
                 .min(Comparator.comparingDouble(pair -> {


### PR DESCRIPTION
moving up from craft result is blocked because deviation is greater than distance*2
moving between crafting/shield slots and armor is also possible when you multiply deviation by 4 for the comparison (scores get bad real fast with deviation, so more straight moves will be preferred)