### PR TITLE
[Update/2.0] Fix a crash on controller carousel screen caused by null controller name

### DIFF
--- a/src/main/java/dev/isxander/controlify/controller/ControllerEntity.java
+++ b/src/main/java/dev/isxander/controlify/controller/ControllerEntity.java
@@ -1,5 +1,6 @@
 package dev.isxander.controlify.controller;
 
+import com.google.common.base.Strings;
 import com.google.gson.Gson;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
@@ -38,7 +39,7 @@ public class ControllerEntity extends ECSEntityImpl {
         String nickname = this.genericConfig().config().nickname;
         if (nickname != null)
             return nickname;
-        return info().type().friendlyName();
+        return Strings.nullToEmpty(info().type().friendlyName());
     }
 
     public Optional<InputComponent> input() {


### PR DESCRIPTION
I used PS3 SIXAXIS controller connected via USB and noticed a crash on controller carousel screen.
Maybe weird choice of a controller but this fixes it.

[crash-2024-03-10_17.32.35-client.txt](https://github.com/isXander/Controlify/files/14551399/crash-2024-03-10_17.32.35-client.txt)
