### PR TITLE
#236: changed check for the presence of the widget on the PauseScreenProcessor

### DIFF
--- a/src/main/java/dev/isxander/controlify/screenop/compat/vanilla/PauseScreenProcessor.java
+++ b/src/main/java/dev/isxander/controlify/screenop/compat/vanilla/PauseScreenProcessor.java
@@ -38,16 +38,20 @@ public class PauseScreenProcessor extends ScreenProcessor<PauseScreen> {
         super.onWidgetRebuild();
 
         if (((PauseScreenAccessor) screen).getShowPauseMenu()) {
-            ButtonGuideApi.addGuideToButton(
-                    (AbstractButton) getWidget("menu.returnToGame").orElseThrow(),
-                    ControlifyBindings.GUI_BACK,
-                    ButtonGuidePredicate.always()
-            );
-            ButtonGuideApi.addGuideToButton(
-                    (AbstractButton) getWidget("menu.options").orElseThrow(),
-                    ControlifyBindings.GUI_ABSTRACT_ACTION_1,
-                    ButtonGuidePredicate.always()
-            );
+            getWidget("menu.returnToGame").ifPresent(widget -> {
+                ButtonGuideApi.addGuideToButton(
+                        (AbstractButton) widget,
+                        ControlifyBindings.GUI_BACK,
+                        ButtonGuidePredicate.always()
+                );
+            });
+            getWidget("menu.options").ifPresent( widget -> {
+                ButtonGuideApi.addGuideToButton(
+                        (AbstractButton) widget,
+                        ControlifyBindings.GUI_ABSTRACT_ACTION_1,
+                        ButtonGuidePredicate.always()
+                );
+            });
             ButtonGuideApi.addGuideToButton(
                     disconnectButtonSupplier.get(),
                     () -> disconnectButtonSupplier.get().isFocused()


### PR DESCRIPTION
Couldn't get Controlify compiling on my end.

Ended up making this fix purely based on how Optionals work in java.

As for the reproduction scenario that can be used to test this fix:
1. Install FTB NeoTech (latest version).
2. Add the 1.20.4 NeoForge version of Controlify to that modpack
3. Launch the modpack
4. Go into a game
5. hit esc to pause, this used to crash.