### PR TITLE
Fixed multiple joystick with same HID data not being differentiated. Fix #376

### DIFF
--- a/src/main/java/dev/isxander/controlify/controllermanager/AbstractControllerManager.java
+++ b/src/main/java/dev/isxander/controlify/controllermanager/AbstractControllerManager.java
@@ -137,7 +137,7 @@ public abstract class AbstractControllerManager implements ControllerManager {
 
     protected int getControllerCountWithMatchingHID(HIDIdentifier hid) {
         return (int) controllersByJid.values().stream()
-                .filter(c -> c.info().hid().equals(Optional.ofNullable(hid)))
+                .filter(c -> c.info().hid().isPresent() && c.info().hid().get().asIdentifier().equals(hid))
                 .count();
     }
 

--- a/src/main/java/dev/isxander/controlify/debug/DebugProperties.java
+++ b/src/main/java/dev/isxander/controlify/debug/DebugProperties.java
@@ -20,6 +20,8 @@ public class DebugProperties {
     public static final boolean PRINT_DRIVER = boolProp("controlify.debug.print_driver", true, true);
     /** Debug dumps after finishing init */
     public static final boolean INIT_DUMP = boolProp("controlify.debug.init_dump", false, true);
+    /** Use SDL Serial number instead of HID+Index **/
+    public static final boolean SDL_USE_SERIAL_NUMBER = boolProp("controlify.debug.sdl_use_serial_number", false, false);
 
     public static void printProperties() {
         if (properties.stream().noneMatch(prop -> prop.enabled() != prop.def()))

--- a/src/main/java/dev/isxander/controlify/debug/DebugProperties.java
+++ b/src/main/java/dev/isxander/controlify/debug/DebugProperties.java
@@ -21,7 +21,7 @@ public class DebugProperties {
     /** Debug dumps after finishing init */
     public static final boolean INIT_DUMP = boolProp("controlify.debug.init_dump", false, true);
     /** Use SDL Serial number instead of HID+Index **/
-    public static final boolean SDL_USE_SERIAL_NUMBER = boolProp("controlify.debug.sdl_use_serial_number", false, false);
+    public static final boolean SDL_USE_SERIAL_FOR_UID = boolProp("controlify.debug.sdl_use_serial_for_uid", false, false);
 
     public static void printProperties() {
         if (properties.stream().noneMatch(prop -> prop.enabled() != prop.def()))

--- a/src/main/java/dev/isxander/controlify/driver/sdl/SDL3GamepadDriver.java
+++ b/src/main/java/dev/isxander/controlify/driver/sdl/SDL3GamepadDriver.java
@@ -94,10 +94,10 @@ public class SDL3GamepadDriver implements Driver {
         this.guid = SDL_GetGamepadInstanceGUID(jid).toString();
         this.serial = SDL_GetGamepadSerial(ptrGamepad);
 
-        if(DebugProperties.SDL_USE_SERIAL_NUMBER) {
-            if(this.serial != null && this.serial.length() > 0) {
+        if (DebugProperties.SDL_USE_SERIAL_NUMBER) {
+            if (this.serial != null && this.serial.length() > 0) {
                 uid = new String();
-                if(hid.isPresent()) {
+                i f(hid.isPresent()) {
                     var hex = HexFormat.of();
                     HIDIdentifier hidIdentifier = hid.get().asIdentifier();
                     uid = "V"

--- a/src/main/java/dev/isxander/controlify/driver/sdl/SDL3GamepadDriver.java
+++ b/src/main/java/dev/isxander/controlify/driver/sdl/SDL3GamepadDriver.java
@@ -94,7 +94,7 @@ public class SDL3GamepadDriver implements Driver {
         this.guid = SDL_GetGamepadInstanceGUID(jid).toString();
         this.serial = SDL_GetGamepadSerial(ptrGamepad);
 
-        if (DebugProperties.SDL_USE_SERIAL_NUMBER) {
+        if (DebugProperties.SDL_USE_SERIAL_FOR_UID) {
             if (this.serial != null && this.serial.length() > 0) {
                 uid = new String();
                 i f(hid.isPresent()) {

--- a/src/main/java/dev/isxander/controlify/driver/sdl/SDL3JoystickDriver.java
+++ b/src/main/java/dev/isxander/controlify/driver/sdl/SDL3JoystickDriver.java
@@ -58,7 +58,7 @@ public class SDL3JoystickDriver implements Driver {
         this.guid = SDL_GetJoystickInstanceGUID(jid).toString();
         this.serial = SDL_GetJoystickSerial(ptrJoystick);
 
-        if (DebugProperties.SDL_USE_SERIAL_NUMBER) {
+        if (DebugProperties.SDL_USE_SERIAL_FOR_UID) {
             if (this.serial != null && this.serial.length() > 0) {
                 uid = new String();
                 if (hid.isPresent()) {

--- a/src/main/java/dev/isxander/controlify/driver/sdl/SDL3JoystickDriver.java
+++ b/src/main/java/dev/isxander/controlify/driver/sdl/SDL3JoystickDriver.java
@@ -58,10 +58,10 @@ public class SDL3JoystickDriver implements Driver {
         this.guid = SDL_GetJoystickInstanceGUID(jid).toString();
         this.serial = SDL_GetJoystickSerial(ptrJoystick);
 
-        if(DebugProperties.SDL_USE_SERIAL_NUMBER) {
-            if(this.serial != null && this.serial.length() > 0) {
+        if (DebugProperties.SDL_USE_SERIAL_NUMBER) {
+            if (this.serial != null && this.serial.length() > 0) {
                 uid = new String();
-                if(hid.isPresent()) {
+                if (hid.isPresent()) {
                     var hex = HexFormat.of();
                     HIDIdentifier hidIdentifier = hid.get().asIdentifier();
                     uid = "V"


### PR DESCRIPTION
Fixed multiple joystick with same HID data not being differentiated.
Added debug configuration for storing controller data based on their serial number (controlify.debug.sdl_use_serial_number).