### PR TITLE
fix: Test rumble was not working due to rumble silencing logic

### DIFF
--- a/src/main/java/dev/isxander/controlify/Controlify.java
+++ b/src/main/java/dev/isxander/controlify/Controlify.java
@@ -43,6 +43,7 @@ import dev.isxander.controlify.utils.*;
 import dev.isxander.controlify.virtualmouse.VirtualMouseHandler;
 import dev.isxander.controlify.wireless.LowBatteryNotifier;
 import dev.isxander.deckapi.api.SteamDeck;
+import dev.isxander.yacl3.gui.YACLScreen;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.screens.PauseScreen;
 import net.minecraft.client.multiplayer.ServerData;
@@ -553,7 +554,10 @@ public class Controlify implements ControlifyApi {
         ControllerStateView state = input.stateNow();
         Optional<RumbleManager> rumbleManager = controller.rumble().map(RumbleComponent::rumbleManager);
 
-        rumbleManager.ifPresent(rumble -> rumble.setSilent(outOfFocus || minecraft.isPaused() || minecraft.screen instanceof PauseScreen));
+        boolean isPaused = minecraft.isPaused() || minecraft.screen instanceof PauseScreen;
+        boolean isConfigScreen = minecraft.screen instanceof YACLScreen;
+
+        rumbleManager.ifPresent(rumble -> rumble.setSilent(outOfFocus || (isPaused && !isConfigScreen)));
         if (outOfFocus) {
             state = ControllerState.EMPTY;
         } else {


### PR DESCRIPTION
This PR fixes the Test Vibration button not working in the controller config screen.

This was because the rumble manager was being silenced when the game was paused. I've added a check to enable the rumble manager when in a `YACLScreen`. This is technically more of a hack, but I'm unsure how better to filter for this specific screen without checking it's title component, which feels somewhat flimsy.

Alternative methods are of course possible, like separating the idea of out-of-focus and silenced to then allow playing vibrations without unsilencing the manager, but I feel the added complexity is likely not warranted.

Please let me know if you'd like anything changed :)