### PR TITLE
Fix: Losing controller config after unplugging twice

### DIFF
--- a/src/main/java/dev/isxander/controlify/config/ControlifyConfig.java
+++ b/src/main/java/dev/isxander/controlify/config/ControlifyConfig.java
@@ -197,7 +197,7 @@ public class ControlifyConfig {
         JsonObject innerJson = json.getAsJsonObject("config");
 
         try {
-            controller.deserializeFromObject(innerJson, GSON);
+            controller.deserializeFromObject(innerJson.deepCopy(), GSON);
         } catch (Exception e) {
             CUtil.LOGGER.error("Failed to load controller {} config!", controller.info().ucid(), e);
             setDirty();


### PR DESCRIPTION
There's the possibility that by unplugging the same controller twice, without pressing or doing anything else between the two unplugging operations, its configuration is lost forever.

The root cause is that deserializeFromObject deletes the keys of the original JSON object as they're traversed.
By providing a deep copy of the JSON object, this issue disappears forever.

While normally it might not be reproducible, this bug is otherwise latent and could be uncovered in the future (i.e. I've discovered it by working on [feature-stop-autoselecting-controllers](https://github.com/EssGeeEich/Controlify/tree/feature-stop-autoselecting-controllers).