### PR TITLE
Feature: Stop autoselecting controllers

### DIFF
--- a/src/main/java/dev/isxander/controlify/config/ControlifyConfig.java
+++ b/src/main/java/dev/isxander/controlify/config/ControlifyConfig.java
@@ -38,6 +38,7 @@ public class ControlifyConfig {
 
     private String currentControllerUid = null;
     // used so saving the config doesn't lose controller config that isn't currently connected
+    // null means no preference, empty string means I don't want to use a controller.
     // key: controller uid
     private final Map<String, JsonObject> storedControllerConfig = new HashMap<>();
     private @NotNull GlobalSettings globalSettings = new GlobalSettings();
@@ -104,7 +105,7 @@ public class ControlifyConfig {
         { // Current controller
             obj.addProperty(
                     "current_controller",
-                    controlify.getCurrentController().map(ControllerEntity::uid).orElse(null)
+                    this.currentControllerUid()
             );
         }
 
@@ -189,7 +190,7 @@ public class ControlifyConfig {
         JsonObject json = storedControllerConfig.get(controller.uid());
 
         if (json == null) {
-            CUtil.LOGGER.warn("Controller {} has no config to load. Using defaults.", controller.info().ucid());
+            CUtil.LOGGER.warn("Controller {} has no config to load. Using defaults.", controller.uid());
             setDirty();
             return true;
         }
@@ -199,7 +200,7 @@ public class ControlifyConfig {
         try {
             controller.deserializeFromObject(innerJson, GSON);
         } catch (Exception e) {
-            CUtil.LOGGER.error("Failed to load controller {} config!", controller.info().ucid(), e);
+            CUtil.LOGGER.error("Failed to load controller {} config!", controller.uid(), e);
             setDirty();
         }
 
@@ -208,6 +209,10 @@ public class ControlifyConfig {
 
     public @Nullable String currentControllerUid() {
         return this.currentControllerUid;
+    }
+
+    public void setCurrentControllerUid(@Nullable String uid) {
+        this.currentControllerUid = uid;
     }
 
     public @NotNull GlobalSettings globalSettings() {

--- a/src/main/java/dev/isxander/controlify/controllermanager/SDLControllerManager.java
+++ b/src/main/java/dev/isxander/controlify/controllermanager/SDLControllerManager.java
@@ -167,6 +167,8 @@ public class SDLControllerManager extends AbstractControllerManager {
         ControllerInfo info = new ControllerInfo(ucid, hidInfo.type(), hidInfo.hidDevice());
         ControllerEntity controller = new ControllerEntity(info, compoundDriver, controllerLogger);
 
+        controllerLogger.debugLog("Unique Controller ID: {}", info.ucid());
+
         this.addController(ucid, controller);
         return Optional.of(controller);
     }

--- a/src/main/java/dev/isxander/controlify/gui/screen/ControllerCalibrationScreen.java
+++ b/src/main/java/dev/isxander/controlify/gui/screen/ControllerCalibrationScreen.java
@@ -170,7 +170,6 @@ public class ControllerCalibrationScreen extends Screen implements DontInteruptS
                 config.calibrated = true;
             });
             Controlify.instance().config().setDirty();
-            Controlify.instance().setCurrentController(controller, true);
             Controlify.instance().config().saveIfDirty();
         }
     }
@@ -270,7 +269,6 @@ public class ControllerCalibrationScreen extends Screen implements DontInteruptS
 
             if (dirty) {
                 Controlify.instance().config().setDirty();
-                Controlify.instance().setCurrentController(null, true);
             }
 
             onClose();

--- a/src/main/java/dev/isxander/controlify/gui/screen/ControllerCarouselScreen.java
+++ b/src/main/java/dev/isxander/controlify/gui/screen/ControllerCarouselScreen.java
@@ -72,7 +72,7 @@ public class ControllerCarouselScreen extends Screen implements ScreenController
     private final Controlify controlify;
     private final ControllerManager controllerManager;
 
-    private Button globalSettingsButton, doneButton;
+    private Button globalSettingsButton, unbindControllerButton, doneButton;
     private Button controllerNotDetectedButton;
 
     private ControllerCarouselScreen(Screen parent) {
@@ -114,6 +114,11 @@ public class ControllerCarouselScreen extends Screen implements ScreenController
         GridLayout grid = new GridLayout().columnSpacing(10);
         GridLayout.RowHelper rowHelper = grid.createRowHelper(2);
         globalSettingsButton = rowHelper.addChild(Button.builder(Component.translatable("controlify.gui.global_settings.title"), btn -> minecraft.setScreen(GlobalSettingsScreenFactory.createGlobalSettingsScreen(this))).build());
+        unbindControllerButton = rowHelper.addChild(Button.builder(Component.translatable("controlify.gui.unbind_controller"), btn -> {
+            // Explicitly unset the controller Uid
+            Controlify.instance().setCurrentController(null, true);
+            Controlify.instance().config().setCurrentControllerUid("");
+        }).build());
         doneButton = rowHelper.addChild(Button.builder(CommonComponents.GUI_DONE, btn -> this.onClose()).build());
         grid.visitWidgets(widget -> {
             widget.setTabOrderGroup(1);

--- a/src/main/resources/assets/controlify/lang/af_za.json
+++ b/src/main/resources/assets/controlify/lang/af_za.json
@@ -10,6 +10,7 @@
   "controlify.gui.carousel.donate": "Donate!",
   "controlify.gui.carousel.art_credit": "Controller art by %s.",
   "controlify.gui.global_settings.title": "Global Settings",
+  "controlify.gui.unbind_controller": "Unbind Controller",
   "controlify.gui.natives": "Natives",
   "controlify.gui.load_vibration_natives": "Load Natives",
   "controlify.gui.load_vibration_natives.tooltip": "If enabled, Controlify will download and load native libraries on launch to enable support for enhanced features such as vibration and gyro. The download process only happens once and only downloads for your specific OS. Disabling this will not delete the natives, it just won't load them.",

--- a/src/main/resources/assets/controlify/lang/ar_sa.json
+++ b/src/main/resources/assets/controlify/lang/ar_sa.json
@@ -10,6 +10,7 @@
   "controlify.gui.carousel.donate": "Donate!",
   "controlify.gui.carousel.art_credit": "Controller art by %s.",
   "controlify.gui.global_settings.title": "Global Settings",
+  "controlify.gui.unbind_controller": "Unbind Controller",
   "controlify.gui.natives": "Natives",
   "controlify.gui.load_vibration_natives": "Load Natives",
   "controlify.gui.load_vibration_natives.tooltip": "If enabled, Controlify will download and load native libraries on launch to enable support for enhanced features such as vibration and gyro. The download process only happens once and only downloads for your specific OS. Disabling this will not delete the natives, it just won't load them.",

--- a/src/main/resources/assets/controlify/lang/ca_es.json
+++ b/src/main/resources/assets/controlify/lang/ca_es.json
@@ -10,6 +10,7 @@
   "controlify.gui.carousel.donate": "Donate!",
   "controlify.gui.carousel.art_credit": "Controller art by %s.",
   "controlify.gui.global_settings.title": "Global Settings",
+  "controlify.gui.unbind_controller": "Unbind Controller",
   "controlify.gui.natives": "Natives",
   "controlify.gui.load_vibration_natives": "Load Natives",
   "controlify.gui.load_vibration_natives.tooltip": "If enabled, Controlify will download and load native libraries on launch to enable support for enhanced features such as vibration and gyro. The download process only happens once and only downloads for your specific OS. Disabling this will not delete the natives, it just won't load them.",

--- a/src/main/resources/assets/controlify/lang/cs_cz.json
+++ b/src/main/resources/assets/controlify/lang/cs_cz.json
@@ -10,6 +10,7 @@
   "controlify.gui.carousel.donate": "Donate!",
   "controlify.gui.carousel.art_credit": "Controller art by %s.",
   "controlify.gui.global_settings.title": "Global Settings",
+  "controlify.gui.unbind_controller": "Unbind Controller",
   "controlify.gui.natives": "Natives",
   "controlify.gui.load_vibration_natives": "Load Natives",
   "controlify.gui.load_vibration_natives.tooltip": "If enabled, Controlify will download and load native libraries on launch to enable support for enhanced features such as vibration and gyro. The download process only happens once and only downloads for your specific OS. Disabling this will not delete the natives, it just won't load them.",

--- a/src/main/resources/assets/controlify/lang/da_dk.json
+++ b/src/main/resources/assets/controlify/lang/da_dk.json
@@ -10,6 +10,7 @@
   "controlify.gui.carousel.donate": "Donate!",
   "controlify.gui.carousel.art_credit": "Controller art by %s.",
   "controlify.gui.global_settings.title": "Global Settings",
+  "controlify.gui.unbind_controller": "Unbind Controller",
   "controlify.gui.natives": "Natives",
   "controlify.gui.load_vibration_natives": "Load Natives",
   "controlify.gui.load_vibration_natives.tooltip": "If enabled, Controlify will download and load native libraries on launch to enable support for enhanced features such as vibration and gyro. The download process only happens once and only downloads for your specific OS. Disabling this will not delete the natives, it just won't load them.",

--- a/src/main/resources/assets/controlify/lang/de_de.json
+++ b/src/main/resources/assets/controlify/lang/de_de.json
@@ -10,6 +10,7 @@
   "controlify.gui.carousel.donate": "Donate!",
   "controlify.gui.carousel.art_credit": "Controller art by %s.",
   "controlify.gui.global_settings.title": "Global Settings",
+  "controlify.gui.unbind_controller": "Unbind Controller",
   "controlify.gui.natives": "Natives",
   "controlify.gui.load_vibration_natives": "Native Dateien runterladen",
   "controlify.gui.load_vibration_natives.tooltip": "Falls aktiviert, läd Controlify beim Start native Dateien, um erweiterte Funktionen wie Vibrationen und Gyro-Steuerung zu unterstützen. Die Dateien werden nur einmal und nur für dein OS heruntergeladen. Dies zu deaktivieren wird die Dateien nicht löschen, sie werden bloß nicht geladen beim nächsten Start.",

--- a/src/main/resources/assets/controlify/lang/el_gr.json
+++ b/src/main/resources/assets/controlify/lang/el_gr.json
@@ -10,6 +10,7 @@
   "controlify.gui.carousel.donate": "Donate!",
   "controlify.gui.carousel.art_credit": "Controller art by %s.",
   "controlify.gui.global_settings.title": "Global Settings",
+  "controlify.gui.unbind_controller": "Unbind Controller",
   "controlify.gui.natives": "Natives",
   "controlify.gui.load_vibration_natives": "Load Natives",
   "controlify.gui.load_vibration_natives.tooltip": "If enabled, Controlify will download and load native libraries on launch to enable support for enhanced features such as vibration and gyro. The download process only happens once and only downloads for your specific OS. Disabling this will not delete the natives, it just won't load them.",

--- a/src/main/resources/assets/controlify/lang/en_gb.json
+++ b/src/main/resources/assets/controlify/lang/en_gb.json
@@ -10,6 +10,7 @@
   "controlify.gui.carousel.donate": "Donate!",
   "controlify.gui.carousel.art_credit": "Controller art by %s.",
   "controlify.gui.global_settings.title": "Global Settings",
+  "controlify.gui.unbind_controller": "Unbind Controller",
   "controlify.gui.natives": "Natives",
   "controlify.gui.load_vibration_natives": "Load Natives",
   "controlify.gui.load_vibration_natives.tooltip": "If enabled, Controlify will download and load native libraries on launch to enable support for enhanced features such as vibration and gyro. The download process only happens once and only downloads for your specific OS. Disabling this will not delete the natives, it just won't load them.",

--- a/src/main/resources/assets/controlify/lang/en_us.json
+++ b/src/main/resources/assets/controlify/lang/en_us.json
@@ -12,6 +12,7 @@
   "controlify.gui.carousel.art_credit": "Controller art by %s.",
 
   "controlify.gui.global_settings.title": "Global Settings",
+  "controlify.gui.unbind_controller": "Unbind Controller",
   "controlify.gui.natives": "Natives",
   "controlify.gui.load_vibration_natives": "Load Natives",
   "controlify.gui.load_vibration_natives.tooltip": "If enabled, Controlify will download and load native libraries on launch to enable support for enhanced features such as vibration and gyro. The download process only happens once and only downloads for your specific OS. Disabling this will not delete the natives, it just won't load them.",

--- a/src/main/resources/assets/controlify/lang/es_es.json
+++ b/src/main/resources/assets/controlify/lang/es_es.json
@@ -10,6 +10,7 @@
   "controlify.gui.carousel.donate": "Donate!",
   "controlify.gui.carousel.art_credit": "Controller art by %s.",
   "controlify.gui.global_settings.title": "Global Settings",
+  "controlify.gui.unbind_controller": "Unbind Controller",
   "controlify.gui.natives": "Natives",
   "controlify.gui.load_vibration_natives": "Load Natives",
   "controlify.gui.load_vibration_natives.tooltip": "If enabled, Controlify will download and load native libraries on launch to enable support for enhanced features such as vibration and gyro. The download process only happens once and only downloads for your specific OS. Disabling this will not delete the natives, it just won't load them.",

--- a/src/main/resources/assets/controlify/lang/es_mx.json
+++ b/src/main/resources/assets/controlify/lang/es_mx.json
@@ -10,6 +10,7 @@
   "controlify.gui.carousel.donate": "¡Donar!",
   "controlify.gui.carousel.art_credit": "Arte del control por %s.",
   "controlify.gui.global_settings.title": "Configuración Global",
+  "controlify.gui.unbind_controller": "Unbind Controller",
   "controlify.gui.natives": "Nativos",
   "controlify.gui.load_vibration_natives": "Cargar Nativos",
   "controlify.gui.load_vibration_natives.tooltip": "Si está habilitado, Controlify descargará y cargará bibliotecas nativas al iniciar para habilitar el soporte de funciones mejoradas como la vibración y el giroscopio. El proceso de descarga solo ocurre una vez y solo se descarga para su sistema operativo específico. Deshabilitar esto no eliminará las bibliotecas nativas, simplemente no las cargará.",

--- a/src/main/resources/assets/controlify/lang/fi_fi.json
+++ b/src/main/resources/assets/controlify/lang/fi_fi.json
@@ -10,6 +10,7 @@
   "controlify.gui.carousel.donate": "Donate!",
   "controlify.gui.carousel.art_credit": "Controller art by %s.",
   "controlify.gui.global_settings.title": "Global Settings",
+  "controlify.gui.unbind_controller": "Unbind Controller",
   "controlify.gui.natives": "Natives",
   "controlify.gui.load_vibration_natives": "Load Natives",
   "controlify.gui.load_vibration_natives.tooltip": "If enabled, Controlify will download and load native libraries on launch to enable support for enhanced features such as vibration and gyro. The download process only happens once and only downloads for your specific OS. Disabling this will not delete the natives, it just won't load them.",

--- a/src/main/resources/assets/controlify/lang/fr_fr.json
+++ b/src/main/resources/assets/controlify/lang/fr_fr.json
@@ -10,6 +10,7 @@
   "controlify.gui.carousel.donate": "Faites un don !",
   "controlify.gui.carousel.art_credit": "Art des manettes par %s.",
   "controlify.gui.global_settings.title": "Paramètres globaux",
+  "controlify.gui.unbind_controller": "Unbind Controller",
   "controlify.gui.natives": "Natives",
   "controlify.gui.load_vibration_natives": "Charger les Natives",
   "controlify.gui.load_vibration_natives.tooltip": "Si activé, Controlify téléchargera et chargera les bibliothèques natives au démarrage pour activer la prise en charge de fonctionnalités améliorées telles que la vibration et le gyroscope. Le processus de téléchargement ne se produit qu'une fois et télécharge uniquement pour votre système d'exploitation spécifique. La désactivation ne supprimera pas les natives, elles ne seront simplement pas chargées.",

--- a/src/main/resources/assets/controlify/lang/he_il.json
+++ b/src/main/resources/assets/controlify/lang/he_il.json
@@ -10,6 +10,7 @@
   "controlify.gui.carousel.donate": "Donate!",
   "controlify.gui.carousel.art_credit": "Controller art by %s.",
   "controlify.gui.global_settings.title": "Global Settings",
+  "controlify.gui.unbind_controller": "Unbind Controller",
   "controlify.gui.natives": "Natives",
   "controlify.gui.load_vibration_natives": "Load Natives",
   "controlify.gui.load_vibration_natives.tooltip": "If enabled, Controlify will download and load native libraries on launch to enable support for enhanced features such as vibration and gyro. The download process only happens once and only downloads for your specific OS. Disabling this will not delete the natives, it just won't load them.",

--- a/src/main/resources/assets/controlify/lang/hu_hu.json
+++ b/src/main/resources/assets/controlify/lang/hu_hu.json
@@ -10,6 +10,7 @@
   "controlify.gui.carousel.donate": "Támogass!",
   "controlify.gui.carousel.art_credit": "A kontroller illusztrációkat %s készítette.",
   "controlify.gui.global_settings.title": "Globális Beállítások",
+  "controlify.gui.unbind_controller": "Unbind Controller",
   "controlify.gui.natives": "Natívok",
   "controlify.gui.load_vibration_natives": "Natívok Betöltése",
   "controlify.gui.load_vibration_natives.tooltip": "Ha be van kapcsolva, a Controlify letölti és betölti a natív könyvtárakat indításnál, hogy lehetővé tegye a fejlett funkciók használatát mint például a vibráció és a giroszkóp. A letöltés csak egyszer történik meg és csak az adott OS-hez való kerül letöltésre. A kikapcsolása nem törli a natívokat, csak nem tölti be őket.",

--- a/src/main/resources/assets/controlify/lang/it_it.json
+++ b/src/main/resources/assets/controlify/lang/it_it.json
@@ -10,6 +10,7 @@
   "controlify.gui.carousel.donate": "Dona!",
   "controlify.gui.carousel.art_credit": "Grafiche controller di %s.",
   "controlify.gui.global_settings.title": "Impostazioni Globali",
+  "controlify.gui.unbind_controller": "Unbind Controller",
   "controlify.gui.natives": "Libr. Native",
   "controlify.gui.load_vibration_natives": "Carica Libr. Native",
   "controlify.gui.load_vibration_natives.tooltip": "Se attivo, Controlify scaricherà e farà uso delle Librerie Native durante l'avvio per attivare il supporto a funzionalità aggiuntive come vibrazione e giroscopio. Il processo di download avviene solo una volta e solo per il vostro sistema operativo specifico. Disattivare questa opzione non eliminerà le librerie native, ma semplicemente non le caricherà.",

--- a/src/main/resources/assets/controlify/lang/ja_jp.json
+++ b/src/main/resources/assets/controlify/lang/ja_jp.json
@@ -10,6 +10,7 @@
   "controlify.gui.carousel.donate": "寄付する!",
   "controlify.gui.carousel.art_credit": "%s によるコントローラーアート",
   "controlify.gui.global_settings.title": "全体設定",
+  "controlify.gui.unbind_controller": "Unbind Controller",
   "controlify.gui.natives": "ネイティブ",
   "controlify.gui.load_vibration_natives": "ネイティブを読み込む",
   "controlify.gui.load_vibration_natives.tooltip": "有効にすると、Controlifyは起動時にネイティブライブラリをダウンロードしてロードし、振動やジャイロなどの拡張機能のサポートを可能にします。 ダウンロードプロセスは一度だけ発生し、特定のOSのダウンロードのみが行われます。これを無効にするとネイティブは削除されず、読み込まれません。",

--- a/src/main/resources/assets/controlify/lang/ko_kr.json
+++ b/src/main/resources/assets/controlify/lang/ko_kr.json
@@ -10,6 +10,7 @@
   "controlify.gui.carousel.donate": "Donate!",
   "controlify.gui.carousel.art_credit": "Controller art by %s.",
   "controlify.gui.global_settings.title": "Global Settings",
+  "controlify.gui.unbind_controller": "Unbind Controller",
   "controlify.gui.natives": "Natives",
   "controlify.gui.load_vibration_natives": "Load Natives",
   "controlify.gui.load_vibration_natives.tooltip": "If enabled, Controlify will download and load native libraries on launch to enable support for enhanced features such as vibration and gyro. The download process only happens once and only downloads for your specific OS. Disabling this will not delete the natives, it just won't load them.",

--- a/src/main/resources/assets/controlify/lang/ms_my.json
+++ b/src/main/resources/assets/controlify/lang/ms_my.json
@@ -10,6 +10,7 @@
   "controlify.gui.carousel.donate": "Derma!",
   "controlify.gui.carousel.art_credit": "Seni lukisan pengawal oleh %s.",
   "controlify.gui.global_settings.title": "Tetapan Global",
+  "controlify.gui.unbind_controller": "Unbind Controller",
   "controlify.gui.natives": "Tempatan",
   "controlify.gui.load_vibration_natives": "Muat Fail Tempatan",
   "controlify.gui.load_vibration_natives.tooltip": "Jika didayakan, Controlify akan memuat turun dan memuatkan pustaka tempatan semasa pelancaran untuk membolehkan sokongan untuk ciri yang dipertingkatkan seperti getaran dan giro. Proses muat turun hanya berlaku sekali dan hanya dimuat turun untuk OS khusus anda. Menyahdayakan ini tidak akan menghapuskan fail tempatan itu, ia cuma tidak akan memuatkannya.",

--- a/src/main/resources/assets/controlify/lang/nl_nl.json
+++ b/src/main/resources/assets/controlify/lang/nl_nl.json
@@ -10,6 +10,7 @@
   "controlify.gui.carousel.donate": "Donate!",
   "controlify.gui.carousel.art_credit": "Controller art by %s.",
   "controlify.gui.global_settings.title": "Global Settings",
+  "controlify.gui.unbind_controller": "Unbind Controller",
   "controlify.gui.natives": "Natives",
   "controlify.gui.load_vibration_natives": "Load Natives",
   "controlify.gui.load_vibration_natives.tooltip": "If enabled, Controlify will download and load native libraries on launch to enable support for enhanced features such as vibration and gyro. The download process only happens once and only downloads for your specific OS. Disabling this will not delete the natives, it just won't load them.",

--- a/src/main/resources/assets/controlify/lang/no_no.json
+++ b/src/main/resources/assets/controlify/lang/no_no.json
@@ -10,6 +10,7 @@
   "controlify.gui.carousel.donate": "Donate!",
   "controlify.gui.carousel.art_credit": "Controller art by %s.",
   "controlify.gui.global_settings.title": "Global Settings",
+  "controlify.gui.unbind_controller": "Unbind Controller",
   "controlify.gui.natives": "Natives",
   "controlify.gui.load_vibration_natives": "Load Natives",
   "controlify.gui.load_vibration_natives.tooltip": "If enabled, Controlify will download and load native libraries on launch to enable support for enhanced features such as vibration and gyro. The download process only happens once and only downloads for your specific OS. Disabling this will not delete the natives, it just won't load them.",

--- a/src/main/resources/assets/controlify/lang/pl_pl.json
+++ b/src/main/resources/assets/controlify/lang/pl_pl.json
@@ -10,6 +10,7 @@
   "controlify.gui.carousel.donate": "Wesprzyj!",
   "controlify.gui.carousel.art_credit": "Grafika kontrolera: %s",
   "controlify.gui.global_settings.title": "Ustawienia globalne",
+  "controlify.gui.unbind_controller": "Unbind Controller",
   "controlify.gui.natives": "Natywy",
   "controlify.gui.load_vibration_natives": "Wczytaj natywy",
   "controlify.gui.load_vibration_natives.tooltip": "Jeśli ta opcja jest włączona, Controlify pobierze i załaduje natywne biblioteki przy uruchomieniu, aby umożliwić obsługę rozszerzonych funkcji, takich jak wibracje i żyroskop. Proces pobierania odbywa się tylko raz i dotyczy wyłącznie konkretnego systemu operacyjnego. Wyłączenie tej opcji nie usunie natywów, po prostu ich nie załaduje.",

--- a/src/main/resources/assets/controlify/lang/pt_br.json
+++ b/src/main/resources/assets/controlify/lang/pt_br.json
@@ -10,6 +10,7 @@
   "controlify.gui.carousel.donate": "Doar!",
   "controlify.gui.carousel.art_credit": "Arte do controlador por %s.",
   "controlify.gui.global_settings.title": "Configurações globais",
+  "controlify.gui.unbind_controller": "Unbind Controller",
   "controlify.gui.natives": "Nativos",
   "controlify.gui.load_vibration_natives": "Carregar Nativos",
   "controlify.gui.load_vibration_natives.tooltip": "Se habilitado, Controle baixará e carregará bibliotecas nativas ao iniciar a habilitação do suporte para recursos aprimorados, como vibração e controle por movimento. O processo de download só acontece uma vez em downloads para o seus sistema operacional específico. Desabilitar isso não apagará os nativos, só não os carregará.",

--- a/src/main/resources/assets/controlify/lang/pt_pt.json
+++ b/src/main/resources/assets/controlify/lang/pt_pt.json
@@ -10,6 +10,7 @@
   "controlify.gui.carousel.donate": "Doar!",
   "controlify.gui.carousel.art_credit": "Arte do comando por %s.",
   "controlify.gui.global_settings.title": "Definições globais",
+  "controlify.gui.unbind_controller": "Unbind Controller",
   "controlify.gui.natives": "Nativos",
   "controlify.gui.load_vibration_natives": "Carregar Nativos",
   "controlify.gui.load_vibration_natives.tooltip": "Se ativado, o Controlify fará o download e carregará bibliotecas nativas ao iniciar, permitindo o suporte a funcionalidades avançadas, como vibração e giroscópio. O processo de download ocorre apenas uma vez e faz o download apenas para o seu sistema operativo específico. Desativar esta opção não irá eliminar as bibliotecas nativas, apenas impedirá que sejam carregadas.",

--- a/src/main/resources/assets/controlify/lang/ro_ro.json
+++ b/src/main/resources/assets/controlify/lang/ro_ro.json
@@ -10,6 +10,7 @@
   "controlify.gui.carousel.donate": "Donează!",
   "controlify.gui.carousel.art_credit": "Controller art by %s.",
   "controlify.gui.global_settings.title": "Setări Globale",
+  "controlify.gui.unbind_controller": "Unbind Controller",
   "controlify.gui.natives": "Native",
   "controlify.gui.load_vibration_natives": "Încarcă Native",
   "controlify.gui.load_vibration_natives.tooltip": "If enabled, Controlify will download and load native libraries on launch to enable support for enhanced features such as vibration and gyro. The download process only happens once and only downloads for your specific OS. Disabling this will not delete the natives, it just won't load them.",

--- a/src/main/resources/assets/controlify/lang/ru_ru.json
+++ b/src/main/resources/assets/controlify/lang/ru_ru.json
@@ -10,6 +10,7 @@
   "controlify.gui.carousel.donate": "Поддержать!",
   "controlify.gui.carousel.art_credit": "Рисунок контроллера от %s.",
   "controlify.gui.global_settings.title": "Глобальные настройки",
+  "controlify.gui.unbind_controller": "Unbind Controller",
   "controlify.gui.natives": "Нативные библиотеки",
   "controlify.gui.load_vibration_natives": "Загружать нативные библиотеки",
   "controlify.gui.load_vibration_natives.tooltip": "Если включено, Controlify будет загружать из сети и включать нативные библиотеки при запуске toдля поддержки таких способностей, как вибрация или гироскоп. Процесс загрузки происходит единожды и именно под вашу ОС. Отключение настройки не удалит библиотеки, они просто не будут грузиться.",

--- a/src/main/resources/assets/controlify/lang/sv_se.json
+++ b/src/main/resources/assets/controlify/lang/sv_se.json
@@ -10,6 +10,7 @@
   "controlify.gui.carousel.donate": "Donate!",
   "controlify.gui.carousel.art_credit": "Controller art by %s.",
   "controlify.gui.global_settings.title": "Global Settings",
+  "controlify.gui.unbind_controller": "Unbind Controller",
   "controlify.gui.natives": "Natives",
   "controlify.gui.load_vibration_natives": "Load Natives",
   "controlify.gui.load_vibration_natives.tooltip": "If enabled, Controlify will download and load native libraries on launch to enable support for enhanced features such as vibration and gyro. The download process only happens once and only downloads for your specific OS. Disabling this will not delete the natives, it just won't load them.",

--- a/src/main/resources/assets/controlify/lang/tr_tr.json
+++ b/src/main/resources/assets/controlify/lang/tr_tr.json
@@ -10,6 +10,7 @@
   "controlify.gui.carousel.donate": "Bağışta bulun!",
   "controlify.gui.carousel.art_credit": "Controller art by %s.",
   "controlify.gui.global_settings.title": "Genel Ayarlar",
+  "controlify.gui.unbind_controller": "Unbind Controller",
   "controlify.gui.natives": "Yerel Dosyalar",
   "controlify.gui.load_vibration_natives": "Yerel Dosyaları Yükle",
   "controlify.gui.load_vibration_natives.tooltip": "Etkinleştirilirse, Controllify titreşim ve gyro gibi gelişmiş özellikler için destek sağlamak üzere başlatma sırasında yerel dosya kütüphaneleri indirir ve yükler. İndirme işlemi yalnızca bir kez gerçekleşir ve yalnızca belirli işletim sisteminiz için indirilir. Bunu devre dışı bırakmak yerel dosyaları silmeyecek, sadece yüklemeyecektir.",

--- a/src/main/resources/assets/controlify/lang/uk_ua.json
+++ b/src/main/resources/assets/controlify/lang/uk_ua.json
@@ -10,6 +10,7 @@
   "controlify.gui.carousel.donate": "Підтримати!",
   "controlify.gui.carousel.art_credit": "Малюнок контролера від %s.",
   "controlify.gui.global_settings.title": "Глобальні налаштування",
+  "controlify.gui.unbind_controller": "Unbind Controller",
   "controlify.gui.natives": "Нативні бібліотеки",
   "controlify.gui.load_vibration_natives": "Завантажувати нативні бібліотеки",
   "controlify.gui.load_vibration_natives.tooltip": "Якщо увімкнено, Controlify завантажуватиме власні бібліотеки під час запуску, щоб увімкнути підтримку розширених функцій, таких як вібрація та гіроскоп. Процес завантаження відбувається лише один раз і завантажується лише для вашої конкретної ОС. Вимкнення цього параметра не призведе до видалення нативних бібліотек, вони просто не будуть завантажуватися.",

--- a/src/main/resources/assets/controlify/lang/vi_vn.json
+++ b/src/main/resources/assets/controlify/lang/vi_vn.json
@@ -10,6 +10,7 @@
   "controlify.gui.carousel.donate": "Donate!",
   "controlify.gui.carousel.art_credit": "Tay cầm được thiết kế bởi %s.",
   "controlify.gui.global_settings.title": "Cài đặt chung",
+  "controlify.gui.unbind_controller": "Unbind Controller",
   "controlify.gui.natives": "Natives",
   "controlify.gui.load_vibration_natives": "Tải gốc",
   "controlify.gui.load_vibration_natives.tooltip": "Nếu được bật, Controlify sẽ tải xuống và tải các thư viện gốc khi khởi chạy để kích hoạt hỗ trợ cho các tính năng nâng cao như rung và con quay hồi chuyển. Quá trình tải xuống chỉ diễn ra một lần và chỉ tải xuống cho hệ điều hành cụ thể của bạn. Vô hiệu hóa điều này sẽ không xóa gốc, nó sẽ không tải chúng.",

--- a/src/main/resources/assets/controlify/lang/zh_cn.json
+++ b/src/main/resources/assets/controlify/lang/zh_cn.json
@@ -10,6 +10,7 @@
   "controlify.gui.carousel.donate": "Donate!",
   "controlify.gui.carousel.art_credit": "手柄由%s设计。",
   "controlify.gui.global_settings.title": "全局设置",
+  "controlify.gui.unbind_controller": "Unbind Controller",
   "controlify.gui.natives": "Natives",
   "controlify.gui.load_vibration_natives": "震动支持",
   "controlify.gui.load_vibration_natives.tooltip": "如果启用，Controlify将在启动时下载并加载本地库以启用震动支持。下载过程只发生一次，并且只下载适用于你的操作系统的文件。禁用它不会删除文件，只是不会加载它们。",

--- a/src/main/resources/assets/controlify/lang/zh_tw.json
+++ b/src/main/resources/assets/controlify/lang/zh_tw.json
@@ -10,6 +10,7 @@
   "controlify.gui.carousel.donate": "贊助！",
   "controlify.gui.carousel.art_credit": "控制器藝術由 %s 提供。",
   "controlify.gui.global_settings.title": "一般設定",
+  "controlify.gui.unbind_controller": "Unbind Controller",
   "controlify.gui.natives": "原生程式庫",
   "controlify.gui.load_vibration_natives": "載入原生程式庫",
   "controlify.gui.load_vibration_natives.tooltip": "若啟用，Controlify 將在啟動時下載並載入原生程式庫，以啟用增強功能的支援，如振動和陀螺儀。下載過程只會發生一次，且只針對你特定的作業系統進行下載。停用此功能不會刪除原生程式庫，只是不會載入它們。",


### PR DESCRIPTION
Breaks automatic selection of the controllers. See below.

Before this PR, Controlify had no option to manually un-set a controller, or to force m+k completely.
This can cause issues in split-screen setups where one player uses the joystick and the other uses mouse+keyboard.

While this can certainly be fixed by removing Controlify within the MC instance that uses mouse+keyboard, this is mostly an issue I encountered when one of my controllers lost connection, and Controlify automatically switched over to the next controller, causing one player to, well, play normally on one screen, and making quite a big mess on the other.

With this change, what happens is that the controller is now "sticky":

- When a controller is selected, either manually (through the Controlify settings) or automatically (i.e. only the VERY first time that Controlify detects a controller), that will become the "preferred controller" for that player
- In order to change the active controller, one MUST enter the Controlify settings
- One can also UNSET the controller within the Controlify settings screen
- Under no other circumstances is the controller switched for the player