### PR TITLE
Use handleScreenVMouse instead of handleButtons

### DIFF
--- a/src/main/java/dev/isxander/controlify/screenop/compat/vanilla/RecipeBookScreenProcessor.java
+++ b/src/main/java/dev/isxander/controlify/screenop/compat/vanilla/RecipeBookScreenProcessor.java
@@ -40,7 +40,7 @@ public class RecipeBookScreenProcessor
 
     @Override
     protected void handleScreenVMouse(ControllerEntity controller, VirtualMouseHandler vmouse) {
-        super.handleButtons(controller);
+        super.handleScreenVMouse(controller, vmouse);
 
         RecipeBookComponent/*? if >=1.21.2 {*/<?>/*?}*/ recipeBookComponent = recipeBookScreenAccessor.getRecipeBookComponent();
 


### PR DESCRIPTION
Only the call 'handleScreenVMouse' implement how to handle the bundle navigation and interface display.