### PR TITLE
Fix Switch 1 Joycons having incorrect button graphics

### DIFF
--- a/src/main/resources/assets/controlify/controllers/controller_identification.json5
+++ b/src/main/resources/assets/controlify/controllers/controller_identification.json5
@@ -70,7 +70,7 @@
 
     "hids": [
       [0x57e, 0x2009], // Many other switch controllers spoof this ID
-      [0x057e, 0x2008], // Switch 1 Joycons (L+R)
+      [0x57e, 0x2008], // Switch 1 Joycons (L+R)
     ]
   },
   {

--- a/src/main/resources/assets/controlify/controllers/controller_identification.json5
+++ b/src/main/resources/assets/controlify/controllers/controller_identification.json5
@@ -70,6 +70,7 @@
 
     "hids": [
       [0x57e, 0x2009], // Many other switch controllers spoof this ID
+      [0x057e, 0x2008], // Switch 1 Joycons (L+R)
     ]
   },
   {


### PR DESCRIPTION
One-liner fix in `controller_identification.json5`. Something similar likely needs to be done for the Switch 2 Joycons and Pro Controller (the latter of which has new buttons!) if they're supported. 