### PR TITLE
[NeoForge] Update "mandatory" field to "type"

### DIFF
--- a/src/main/templates/META-INF/neoforge.mods.toml
+++ b/src/main/templates/META-INF/neoforge.mods.toml
@@ -15,14 +15,14 @@ logoFile = "icon.png"
 
 [[dependencies."${mod_id}"]]
 modId = "minecraft"
-mandatory = true
+type = "required"
 versionRange = "${mc}"
 ordering = "NONE"
 side = "BOTH"
 
 [[dependencies."${mod_id}"]]
 modId = "yet_another_config_lib_v3"
-mandatory = true
+type = "required"
 versionRange = "[3.8,4)"
 ordering = "NONE"
 side = "BOTH"


### PR DESCRIPTION
It looks like the `mandatory` is Forge-specific and is ignored by NeoForge, which has the`type` field.

To confirm this, open [NeoForge mod generator](https://neoforged.net/mod-generator/), click `Preview Mod Project` and navigate to `src/main/templates/META-INF/neoforge.mods.toml` for the up-to-date template.