### PR TITLE
[Steam Deck] Add missing return statement to fix game launch crashes?

### DIFF
--- a/src/main/java/dev/isxander/controlify/driver/steamdeck/SteamDeckUtil.java
+++ b/src/main/java/dev/isxander/controlify/driver/steamdeck/SteamDeckUtil.java
@@ -55,6 +55,7 @@ public final class SteamDeckUtil {
     private static boolean isHardwareSteamDeck() {
         if (true) {
             logger.error("Skipping Steam Deck checks as steamOS has temporarily broken the enhaned driver.");
+            return false;
         }
 
         logger.debugLog("Checking if hardware is Steam Deck.");


### PR DESCRIPTION
Ports [this commit](https://github.com/EchoEllet/Controlify/pull/2/commits/279b831db95d4f31e9fea45e0c3883a547e4a0f6) from my fork.

I don't have a Steam Deck device, though some users reported [this issue](https://github.com/EchoEllet/Controlify/issues/1):

> "dev.isxander.deckapi.api.ControllerState.getButtonState(dev.isxander.deckapi.api.ControllerButton)" because "deckState" is null

They have [confirmed that this patch fixed the issue](https://github.com/EchoEllet/Controlify/issues/1#issuecomment-3516355385), but I'm still not entirely certain, as this is on 1.20.1 and my branch was based on [Controlify 2.1.2](https://modrinth.com/mod/controlify/version/gYWWawgz), with some manual backports (no cherry-picking) to make it "just work".

So this might not be an appropriate fix; it's possible that this fixed the crash but caused misleading behavior or minor issues. 