### PR TITLE
Update Zoomify dependency version to <=2.15.1

### DIFF
--- a/src/main/templates/fabric.mod.json
+++ b/src/main/templates/fabric.mod.json
@@ -41,7 +41,7 @@
   "breaks": {
     "midnightcontrols": "*",
     "controllable": "*",
-    "zoomify": "<=2.13.4",
+    "zoomify": "<=2.15.1",
     "do_a_barrel_roll": "<=3.5.8"
   }
 }


### PR DESCRIPTION
Helps users see the Controlify incompatibility right on launch, rather than waiting for a crash.