### PR TITLE
Fixed Radial Menu Crash

### DIFF
--- a/src/main/java/dev/isxander/controlify/config/settings/profile/InputSettings.java
+++ b/src/main/java/dev/isxander/controlify/config/settings/profile/InputSettings.java
@@ -11,6 +11,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.ArrayList;
+
 
 public class InputSettings {
     public final BindingsSettings bindings;
@@ -147,7 +149,7 @@ public class InputSettings {
             if (radialActions.size() != 8) {
                 throw new IllegalArgumentException("radialActions must have exactly 8 elements");
             }
-            this.radialActions = List.copyOf(radialActions);
+            this.radialActions = new ArrayList<>(radialActions);
             this.radialButtonFocusTimeoutTicks = radialButtonFocusTimeoutTicks;
         }
 


### PR DESCRIPTION
Updated InputSettings.RadialMenuSettings to properly initialize radialActions as a mutable ArrayList to prevent compilation errors and added missing import for java.util.ArrayList in InputSettings.java.

Tested on Steam Deck only and verified it works, unsure about other input methods. While this patch doesn't change device-specific functionality, I would still suggest testing it on other controllers.