### PR TITLE
Fix: normalize movement vector for 1.21.5+ (fixes #831)

### DIFF
--- a/src/main/java/dev/isxander/controlify/ingame/ControllerPlayerMovement.java
+++ b/src/main/java/dev/isxander/controlify/ingame/ControllerPlayerMovement.java
@@ -93,11 +93,20 @@ public class ControllerPlayerMovement extends ClientInput {
         so this won't actually make any difference for most people.
         But custom joystick configurations may produce irregular results, hence this is necessary.
          */
+        //? if >=1.21.5 {
+        /*
+        // Starting snapshot 25w02a, move vector is now normalised.
+        // This slows down the player when moving diagonally, this will be reflected
+        // by Controlify. This means that 25w02a and later targets will have differing movement mechanics
+        // in Controlify.
+        this.moveVector = new Vec2(left, forward).normalized();
+        *///?} else {
         this.moveVector = new Vec2(left, forward);
         float length = this.moveVector.length();
         if (length > 1) {
             this.moveVector = this.moveVector.scale(1f / length);
         }
+        //?}
     }
 
     public static void updatePlayerInput(@Nullable LocalPlayer player) {


### PR DESCRIPTION
## Description
This PR fixes the jittery movement issue reported in #831 for Minecraft 1.21.11.

## Problem
Starting from Minecraft snapshot 25w02a (1.21.5+), the vanilla movement vector is normalized. However, Controlify was only limiting the vector length to 1 without normalizing it, causing inconsistent movement behavior, especially noticeable on multiplayer servers.

## Solution
Added preprocessor directive to normalize the movement vector for versions >= 1.21.5, matching vanilla behavior. This ensures smooth, consistent movement across all directions.

## Changes
- Modified  to use  for 1.21.5+ targets
- Preserves the old behavior for earlier versions to maintain compatibility

## Testing
- Fixes jittery movement on Hypixel and other multiplayer servers
- Maintains analogue input sensitivity (not forced to full speed)
- Diagonal movement now matches vanilla behavior