### PR TITLE
fix: support Cobblemon Rider jump and sneak inputs

### DIFF
--- a/src/main/java/dev/isxander/controlify/compatibility/ControlifyCompat.java
+++ b/src/main/java/dev/isxander/controlify/compatibility/ControlifyCompat.java
@@ -16,8 +16,18 @@ public class ControlifyCompat {
     public static final String IMMEDIATELY_FAST = "immediatelyfast";
     public static final String SIMPLE_VOICE_CHAT = "voicechat";
     public static final String FANCY_MENU = "fancymenu";
+    public static final String COBBLEMON_RIDING_FABRIC = "cobblemonridingfabric";
 
     public static void init() {
+        try {
+            wrapCompatCall(
+                    COBBLEMON_RIDING_FABRIC,
+                    dev.isxander.controlify.compatibility.cobblemonriding.CobblemonRidingCompat::init
+            );
+        } catch (NoClassDefFoundError e) {
+            disabledMods.add(COBBLEMON_RIDING_FABRIC);
+        }
+
         //? if simple_voice_chat {
         try {
             wrapCompatCall(

--- a/src/main/java/dev/isxander/controlify/compatibility/cobblemonriding/CobblemonRidingCompat.java
+++ b/src/main/java/dev/isxander/controlify/compatibility/cobblemonriding/CobblemonRidingCompat.java
@@ -1,0 +1,69 @@
+package dev.isxander.controlify.compatibility.cobblemonriding;
+
+import dev.isxander.controlify.api.event.ControlifyEvents;
+import dev.isxander.controlify.bindings.ControlifyBindings;
+import dev.isxander.controlify.bindings.KeyMappingHandle;
+import dev.isxander.controlify.controller.ControllerEntity;
+import net.minecraft.client.KeyMapping;
+import net.minecraft.client.Minecraft;
+import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.resources.Identifier;
+import net.minecraft.world.entity.Entity;
+
+public final class CobblemonRidingCompat {
+    private static final String COBBLEMON_NAMESPACE = "cobblemon";
+
+    private static boolean jumpPressed;
+    private static boolean sneakPressed;
+
+    public static void init() {
+        ControlifyEvents.ACTIVE_CONTROLLER_TICKED.register(event -> tick(event.controller()));
+        ControlifyEvents.INPUT_MODE_CHANGED.register(event -> releaseAll());
+    }
+
+    private static void tick(ControllerEntity controller) {
+        Minecraft minecraft = Minecraft.getInstance();
+        if (!shouldEmulateVanillaKeys(minecraft)) {
+            releaseAll();
+            return;
+        }
+
+        setPressed(minecraft.options.keyJump, ControlifyBindings.JUMP.on(controller).digitalNow(), true);
+        setPressed(minecraft.options.keyShift, ControlifyBindings.SNEAK.on(controller).digitalNow(), false);
+    }
+
+    private static boolean shouldEmulateVanillaKeys(Minecraft minecraft) {
+        if (minecraft.player == null || minecraft.screen != null)
+            return false;
+
+        Entity vehicle = minecraft.player.getVehicle();
+        if (vehicle == null)
+            return false;
+
+        Identifier vehicleId = BuiltInRegistries.ENTITY_TYPE.getKey(vehicle.getType());
+        return vehicleId != null && COBBLEMON_NAMESPACE.equals(vehicleId.getNamespace());
+    }
+
+    private static void releaseAll() {
+        Minecraft minecraft = Minecraft.getInstance();
+        setPressed(minecraft.options.keyJump, false, true);
+        setPressed(minecraft.options.keyShift, false, false);
+    }
+
+    private static void setPressed(KeyMapping keyMapping, boolean pressed, boolean jump) {
+        boolean wasPressed = jump ? jumpPressed : sneakPressed;
+        if (wasPressed == pressed)
+            return;
+
+        ((KeyMappingHandle) keyMapping).controlify$setPressed(pressed);
+
+        if (jump) {
+            jumpPressed = pressed;
+        } else {
+            sneakPressed = pressed;
+        }
+    }
+
+    private CobblemonRidingCompat() {
+    }
+}


### PR DESCRIPTION
Fixes #590.

CobblemonRider reads the vanilla jump and sneak key mappings in its client tick before sending mount-control packets. Controlify was already handling those actions through player movement input, but the vanilla key mappings stayed unpressed, so Cobblemon mounts never saw controller jump/ascend or sneak/descend.

This adds a small compatibility hook for `cobblemonridingfabric` that mirrors Controlify jump and sneak into the vanilla key mappings only while the player is riding a Cobblemon entity, then releases them when the player dismounts, opens a screen, or leaves controller input mode. Sprint is already covered by the existing key emulation on the sprint binding.

Verification:
- `JAVA_HOME=/opt/homebrew/opt/openjdk/libexec/openjdk.jdk/Contents/Home ./gradlew :26.1-fabric:compileJava`