### PR TITLE
Emulate vanilla jump and sneak key states

### DIFF
--- a/src/main/java/dev/isxander/controlify/bindings/ControlifyBindings.java
+++ b/src/main/java/dev/isxander/controlify/bindings/ControlifyBindings.java
@@ -2,6 +2,7 @@ package dev.isxander.controlify.bindings;
 
 import dev.isxander.controlify.api.bind.ControlifyBindApi;
 import dev.isxander.controlify.api.bind.InputBindingSupplier;
+import dev.isxander.controlify.controller.ControllerEntity;
 import dev.isxander.controlify.platform.client.PlatformClientUtil;
 import dev.isxander.controlify.utils.CUtil;
 import net.minecraft.ChatFormatting;
@@ -75,6 +76,7 @@ public final class ControlifyBindings {
             .id("controlify", "jump")
             .category(MOVEMENT_CATEGORY)
             .allowedContexts(BindContext.IN_GAME)
+            .keyEmulation(options.keyJump)
             .radialCandidate(RadialIcons.getEffect(MobEffects.JUMP_BOOST)));
     public static final InputBindingSupplier SPRINT = ControlifyBindApi.get().registerBinding(builder -> builder
             .id("controlify", "sprint")
@@ -85,7 +87,7 @@ public final class ControlifyBindings {
             .id("controlify", "sneak")
             .category(MOVEMENT_CATEGORY)
             .allowedContexts(BindContext.IN_GAME)
-            .addKeyCorrelation(options.keyShift));
+            .keyEmulation(options.keyShift, ControlifyBindings::shouldToggleSneak));
 
     public static final InputBindingSupplier ATTACK = ControlifyBindApi.get().registerBinding(builder -> builder
             .id("controlify", "attack")
@@ -418,6 +420,15 @@ public final class ControlifyBindings {
                 CUtil.LOGGER.error("Failed to automatically register modded keybind: {}", keyMapping.getName(), e);
             }
         }
+    }
+
+    private static boolean shouldToggleSneak(ControllerEntity controller) {
+        var player = Minecraft.getInstance().player;
+        return controller.settings().generic.toggleSneak
+                && player != null
+                && !player.getAbilities().flying
+                && !(player.isInWater() && !player.onGround())
+                && player.getVehicle() == null;
     }
 
     private ControlifyBindings() {

--- a/src/main/java/dev/isxander/controlify/bindings/output/KeyMappingEmulationOutput.java
+++ b/src/main/java/dev/isxander/controlify/bindings/output/KeyMappingEmulationOutput.java
@@ -14,12 +14,16 @@ public class KeyMappingEmulationOutput implements DigitalOutput {
     private final ControllerEntity controller;
     private final StateAccess stateAccess;
     private final KeyMapping keyMapping;
+    private final boolean waitForReleaseAfterSuppression;
+    private boolean waitingForRelease;
     private boolean pressed;
 
     public KeyMappingEmulationOutput(ControllerEntity controller, InputBinding binding, KeyMapping keyMapping, BooleanSupplier toggleCondition) {
         this.controller = controller;
         this.stateAccess = binding.createStateAccess(1, state -> push());
         this.keyMapping = keyMapping;
+        // Jump already has movement-side handling to avoid jumping after closing a GUI with the button held.
+        this.waitForReleaseAfterSuppression = keyMapping == Minecraft.getInstance().options.keyJump;
 
         if (toggleCondition != null) {
             ((KeyMappingHandle) keyMapping).controlify$addToggleCondition(controller, toggleCondition);
@@ -33,10 +37,19 @@ public class KeyMappingEmulationOutput implements DigitalOutput {
 
     private void push() {
         boolean nextPressed = stateAccess.digital(0);
-
-        if (stateAccess.isSuppressed()
+        boolean suppressed = stateAccess.isSuppressed()
                 || ControlifyApi.get().getCurrentController().orElse(null) != controller
-                || Minecraft.getInstance().screen != null) {
+                || Minecraft.getInstance().screen != null;
+
+        if (waitForReleaseAfterSuppression) {
+            if (!nextPressed) {
+                waitingForRelease = false;
+            } else if (suppressed) {
+                waitingForRelease = true;
+            }
+        }
+
+        if (suppressed || waitingForRelease) {
             nextPressed = false;
         }
 

--- a/src/main/java/dev/isxander/controlify/bindings/output/KeyMappingEmulationOutput.java
+++ b/src/main/java/dev/isxander/controlify/bindings/output/KeyMappingEmulationOutput.java
@@ -14,10 +14,11 @@ public class KeyMappingEmulationOutput implements DigitalOutput {
     private final ControllerEntity controller;
     private final StateAccess stateAccess;
     private final KeyMapping keyMapping;
+    private boolean pressed;
 
     public KeyMappingEmulationOutput(ControllerEntity controller, InputBinding binding, KeyMapping keyMapping, BooleanSupplier toggleCondition) {
         this.controller = controller;
-        this.stateAccess = binding.createStateAccess(2, state -> push());
+        this.stateAccess = binding.createStateAccess(1, state -> push());
         this.keyMapping = keyMapping;
 
         if (toggleCondition != null) {
@@ -31,20 +32,18 @@ public class KeyMappingEmulationOutput implements DigitalOutput {
     }
 
     private void push() {
-        boolean now = stateAccess.digital(0);
-        boolean prev = stateAccess.digital(1);
+        boolean nextPressed = stateAccess.digital(0);
 
-        if (ControlifyApi.get().getCurrentController().orElse(null) != controller)
-            return; // only emulate current controller
-
-        if (Minecraft.getInstance().screen != null)
-            return; // minecraft keybinds don't work in gui screens it conflicts
-
-        KeyMappingHandle handle = (KeyMappingHandle) keyMapping;
-        if (now && !prev) {
-            handle.controlify$setPressed(true);
-        } else if (prev && !now) {
-            handle.controlify$setPressed(false);
+        if (stateAccess.isSuppressed()
+                || ControlifyApi.get().getCurrentController().orElse(null) != controller
+                || Minecraft.getInstance().screen != null) {
+            nextPressed = false;
         }
+
+        if (pressed == nextPressed)
+            return;
+
+        ((KeyMappingHandle) keyMapping).controlify$setPressed(nextPressed);
+        pressed = nextPressed;
     }
 }


### PR DESCRIPTION
## Summary
- make Controlify's Jump binding emulate the vanilla jump key mapping
- make Sneak emulate the vanilla sneak key mapping while reusing Controlify's existing contextual toggle rules
- make key emulation release held keys when the binding is suppressed, a GUI is open, or another controller becomes active

This fixes controller compatibility for mods that read `options.keyJump` / `options.keyShift` directly, including Cobblemon Rider mounts, without adding a Cobblemon-specific compatibility hook.

Closes #590.

## Verification
- `git diff --check`
- `JAVA_HOME=/Users/shriramvasudevan/.cache/codex-jdks/jdk-25.0.3+9/Contents/Home PATH=/Users/shriramvasudevan/.cache/codex-jdks/jdk-25.0.3+9/Contents/Home/bin:$PATH ./gradlew :26.1-fabric:compileJava`

`./gradlew :26.1-neoforge:compileJava --stacktrace` currently fails before source compilation in `:26.1-neoforge:createMinecraftMappings` because `org.gradle.toolchains.foojay.DistributionsKt` references `JvmVendorSpec.IBM_SEMERU`, which is not present in this Gradle runtime.
