### PR TITLE
Fix Cobblemon Rider jump and sneak inputs

### DIFF
--- a/src/main/java/dev/isxander/controlify/bindings/ControlifyBindings.java
+++ b/src/main/java/dev/isxander/controlify/bindings/ControlifyBindings.java
@@ -2,6 +2,7 @@ package dev.isxander.controlify.bindings;
 
 import dev.isxander.controlify.api.bind.ControlifyBindApi;
 import dev.isxander.controlify.api.bind.InputBindingSupplier;
+import dev.isxander.controlify.controller.ControllerEntity;
 import dev.isxander.controlify.platform.client.PlatformClientUtil;
 import dev.isxander.controlify.utils.CUtil;
 import net.minecraft.ChatFormatting;
@@ -75,6 +76,7 @@ public final class ControlifyBindings {
             .id("controlify", "jump")
             .category(MOVEMENT_CATEGORY)
             .allowedContexts(BindContext.IN_GAME)
+            .keyEmulation(options.keyJump)
             .radialCandidate(RadialIcons.getEffect(MobEffects.JUMP_BOOST)));
     public static final InputBindingSupplier SPRINT = ControlifyBindApi.get().registerBinding(builder -> builder
             .id("controlify", "sprint")
@@ -85,7 +87,7 @@ public final class ControlifyBindings {
             .id("controlify", "sneak")
             .category(MOVEMENT_CATEGORY)
             .allowedContexts(BindContext.IN_GAME)
-            .addKeyCorrelation(options.keyShift));
+            .keyEmulation(options.keyShift, ControlifyBindings::shouldToggleSneak));
 
     public static final InputBindingSupplier ATTACK = ControlifyBindApi.get().registerBinding(builder -> builder
             .id("controlify", "attack")
@@ -418,6 +420,15 @@ public final class ControlifyBindings {
                 CUtil.LOGGER.error("Failed to automatically register modded keybind: {}", keyMapping.getName(), e);
             }
         }
+    }
+
+    private static boolean shouldToggleSneak(ControllerEntity controller) {
+        var player = Minecraft.getInstance().player;
+        return controller.settings().generic.toggleSneak
+                && player != null
+                && !player.getAbilities().flying
+                && !(player.isInWater() && !player.onGround())
+                && player.getVehicle() == null;
     }
 
     private ControlifyBindings() {

--- a/src/main/java/dev/isxander/controlify/bindings/KeyMappingHandle.java
+++ b/src/main/java/dev/isxander/controlify/bindings/KeyMappingHandle.java
@@ -7,5 +7,7 @@ import java.util.function.BooleanSupplier;
 public interface KeyMappingHandle {
     void controlify$setPressed(boolean isDown);
 
+    void controlify$forceSetPressed(boolean isDown);
+
     void controlify$addToggleCondition(ControllerEntity controller, BooleanSupplier condition);
 }

--- a/src/main/java/dev/isxander/controlify/bindings/output/KeyMappingEmulationOutput.java
+++ b/src/main/java/dev/isxander/controlify/bindings/output/KeyMappingEmulationOutput.java
@@ -14,10 +14,12 @@ public class KeyMappingEmulationOutput implements DigitalOutput {
     private final ControllerEntity controller;
     private final StateAccess stateAccess;
     private final KeyMapping keyMapping;
+    private boolean pressed;
+    private boolean waitingForRelease;
 
     public KeyMappingEmulationOutput(ControllerEntity controller, InputBinding binding, KeyMapping keyMapping, BooleanSupplier toggleCondition) {
         this.controller = controller;
-        this.stateAccess = binding.createStateAccess(2, state -> push());
+        this.stateAccess = binding.createStateAccess(1, state -> push());
         this.keyMapping = keyMapping;
 
         if (toggleCondition != null) {
@@ -31,20 +33,23 @@ public class KeyMappingEmulationOutput implements DigitalOutput {
     }
 
     private void push() {
-        boolean now = stateAccess.digital(0);
-        boolean prev = stateAccess.digital(1);
+        boolean inputPressed = stateAccess.digital(0);
+        boolean suppressed = stateAccess.isSuppressed()
+                || ControlifyApi.get().getCurrentController().orElse(null) != controller
+                || !ControlifyApi.get().currentInputMode().isController()
+                || Minecraft.getInstance().screen != null;
 
-        if (ControlifyApi.get().getCurrentController().orElse(null) != controller)
-            return; // only emulate current controller
-
-        if (Minecraft.getInstance().screen != null)
-            return; // minecraft keybinds don't work in gui screens it conflicts
-
-        KeyMappingHandle handle = (KeyMappingHandle) keyMapping;
-        if (now && !prev) {
-            handle.controlify$setPressed(true);
-        } else if (prev && !now) {
-            handle.controlify$setPressed(false);
+        if (!inputPressed) {
+            waitingForRelease = false;
+        } else if (suppressed) {
+            waitingForRelease = true;
         }
+
+        boolean nextPressed = inputPressed && !suppressed && !waitingForRelease;
+        if (pressed == nextPressed)
+            return;
+
+        ((KeyMappingHandle) keyMapping).controlify$setPressed(nextPressed);
+        pressed = nextPressed;
     }
 }

--- a/src/main/java/dev/isxander/controlify/bindings/output/KeyMappingEmulationOutput.java
+++ b/src/main/java/dev/isxander/controlify/bindings/output/KeyMappingEmulationOutput.java
@@ -14,15 +14,19 @@ public class KeyMappingEmulationOutput implements DigitalOutput {
     private final ControllerEntity controller;
     private final StateAccess stateAccess;
     private final KeyMapping keyMapping;
+    private final BooleanSupplier toggleCondition;
     private boolean pressed;
     private boolean waitingForRelease;
+    private boolean lastToggleMode;
 
     public KeyMappingEmulationOutput(ControllerEntity controller, InputBinding binding, KeyMapping keyMapping, BooleanSupplier toggleCondition) {
         this.controller = controller;
         this.stateAccess = binding.createStateAccess(1, state -> push());
         this.keyMapping = keyMapping;
+        this.toggleCondition = toggleCondition;
 
         if (toggleCondition != null) {
+            lastToggleMode = toggleCondition.getAsBoolean();
             ((KeyMappingHandle) keyMapping).controlify$addToggleCondition(controller, toggleCondition);
         }
     }
@@ -34,6 +38,15 @@ public class KeyMappingEmulationOutput implements DigitalOutput {
 
     private void push() {
         boolean inputPressed = stateAccess.digital(0);
+        boolean toggleMode = toggleCondition != null && toggleCondition.getAsBoolean();
+
+        if (pressed && toggleMode != lastToggleMode) {
+            ((KeyMappingHandle) keyMapping).controlify$forceSetPressed(false);
+            pressed = false;
+            waitingForRelease = inputPressed;
+        }
+        lastToggleMode = toggleMode;
+
         boolean suppressed = stateAccess.isSuppressed()
                 || ControlifyApi.get().getCurrentController().orElse(null) != controller
                 || !ControlifyApi.get().currentInputMode().isController()

--- a/src/main/java/dev/isxander/controlify/mixins/feature/bind/KeyMappingMixin.java
+++ b/src/main/java/dev/isxander/controlify/mixins/feature/bind/KeyMappingMixin.java
@@ -29,6 +29,11 @@ public class KeyMappingMixin implements KeyMappingHandle {
     }
 
     @Override
+    public void controlify$forceSetPressed(boolean isDown) {
+        controlify$setPressed(isDown);
+    }
+
+    @Override
     public void controlify$addToggleCondition(ControllerEntity controller, BooleanSupplier condition) {
 
     }

--- a/src/main/java/dev/isxander/controlify/mixins/feature/bind/ToggleKeyMappingMixin.java
+++ b/src/main/java/dev/isxander/controlify/mixins/feature/bind/ToggleKeyMappingMixin.java
@@ -26,6 +26,11 @@ public abstract class ToggleKeyMappingMixin extends KeyMappingMixin implements K
         this.setDown(isDown);
     }
 
+    @Override
+    public void controlify$forceSetPressed(boolean isDown) {
+        super.controlify$setPressed(isDown);
+    }
+
     @ModifyExpressionValue(method = "setDown", at = @At(value = "INVOKE", target = "Ljava/util/function/BooleanSupplier;getAsBoolean()Z"))
     private boolean modifyToggleMode(boolean vanillaToggleMode) {
         if (Controlify.instance().currentInputMode().isController()) {


### PR DESCRIPTION
Fixes #590.

Cobblemon Rider reads the vanilla jump and sneak key mappings in its client tick before sending mount-control packets. Controlify already updates `player.input` for controller jump/sneak, but those vanilla key mappings were not being emulated for the built-in jump and sneak bindings.

This change routes Jump and Sneak through Controlify's existing key-emulation output, keeps Sneak's toggle condition aligned with the movement code, and makes key emulation release and wait for a fresh press whenever the binding is suppressed, a GUI is open, the active controller changes, or input mode is not controller-driven.

Verification:
- `git diff --check`
- `JAVA_HOME=/opt/homebrew/opt/openjdk@25 PATH=/opt/homebrew/opt/openjdk@25/bin:$PATH GRADLE_USER_HOME=/tmp/controlify_gradle_home /tmp/controlify_gradle/gradle-9.4.0/bin/gradle :26.1-fabric:compileJava`

NeoForge note: `:26.1-neoforge:compileJava` did not reach source compilation. One attempt hit a 502 from `maven.neoforged.net`; the retry failed during mapping setup with `JvmVendorSpec.IBM_SEMERU` missing from Gradle's toolchain API.
