### PR TITLE
Fix mixed input leaving the virtual mouse unresponsive for 2 seconds

### DIFF
--- a/src/main/java/dev/isxander/controlify/Controlify.java
+++ b/src/main/java/dev/isxander/controlify/Controlify.java
@@ -106,6 +106,7 @@ public class Controlify implements ControlifyApi {
 	private double lastInputSwitchTime = 0;
 
 	private int showMouseTicks = 0;
+	private boolean mouseUsedThisTick = false;
 
 	/**
 	 * Called at usual fabric client entrypoint and in NeoForge mod constructor
@@ -472,10 +473,7 @@ public class Controlify implements ControlifyApi {
 		if (currentInputMode() == InputMode.MIXED && showMouseTicks > 0) {
 			showMouseTicks--;
 			if (showMouseTicks == 0) {
-				hideMouse(true, false);
-				if (virtualMouseHandler().requiresVirtualMouse()) {
-					virtualMouseHandler().enableVirtualMouse();
-				}
+				restoreVirtualCursor();
 			}
 		}
 
@@ -497,6 +495,8 @@ public class Controlify implements ControlifyApi {
 					controller
 			);
 		}
+
+		mouseUsedThisTick = false;
 	}
 
 	/**
@@ -528,6 +528,10 @@ public class Controlify implements ControlifyApi {
 
 				return; // don't process input if this is changing mode.
 			}
+		}
+
+		if (showMouseTicks > 0 && !mouseUsedThisTick && state.isGivingInput()) {
+			this.endTemporaryCursor();
 		}
 
 		if (consecutiveInputSwitches > 100) {
@@ -726,11 +730,26 @@ public class Controlify implements ControlifyApi {
 
 	public void showCursorTemporarily() {
 		if (currentInputMode() == InputMode.MIXED && !minecraft.mouseHandler.isMouseGrabbed()) {
+			mouseUsedThisTick = true;
 			hideMouse(false, false);
 			showMouseTicks = 20 * 2;
 			if (virtualMouseHandler().isVirtualMouseEnabled()) {
 				virtualMouseHandler().disableVirtualMouse();
 			}
+		}
+	}
+
+	public void endTemporaryCursor() {
+		if (currentInputMode() != InputMode.MIXED || showMouseTicks <= 0) return;
+
+		showMouseTicks = 0;
+		restoreVirtualCursor();
+	}
+
+	private void restoreVirtualCursor() {
+		hideMouse(true, false);
+		if (virtualMouseHandler().requiresVirtualMouse()) {
+			virtualMouseHandler().enableVirtualMouse();
 		}
 	}
 


### PR DESCRIPTION
## Problem

With Mixed Input enabled, the virtual mouse goes dead for two seconds every time you touch the native mouse.

The main advantage of mixed input is that you can switch freely between controller and M+K. As it stands, this works for all inputs except for virtual vs native mouse. This is particularly evident when using gyro-to-mouse to move the camera, but the joystick/D-Pad to move around inventories. A 2s delay for switching becomes a real issue when wanting to quickly switch between gameplay and inventory management. This is a very common setup, so as not to have to rely on mouse emulation through joystick.

This is [#130](https://github.com/isXander/Controlify/issues/130). That was closed by shortening the wait from three seconds to two, which made it less annoying without removing it.

## Steps to Reproduce

1. Set your controller to control the native mouse.
2. Jiggle the controller input that controls the mouse and quickly open the inventory.
3. Immediately try to use the virtual mouse.

### Before This Fix

* Virtual mouse is unresponsive for 2s.

https://github.com/user-attachments/assets/2335c4aa-31ef-4408-9c52-43b969612667

### After This Fix

* Virtual mouse is responsive immediately.

https://github.com/user-attachments/assets/0dd2c228-e39d-4dd8-bf9d-4f1e287f1cb6

## Testing

- Green on CI across all targets in `versions.json`.
